### PR TITLE
Implement paginated monster query feature flag

### DIFF
--- a/app/.well-known/vercel/flags/route.ts
+++ b/app/.well-known/vercel/flags/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { verifyAccess, type ApiData } from '@vercel/flags';
+
+export async function GET(request: NextRequest) {
+  const access = await verifyAccess(request.headers.get('Authorization'));
+  if (!access) return NextResponse.json(null, { status: 401 });
+
+  return NextResponse.json<ApiData>({
+    definitions: {
+      'paginate-monsters': {
+        description: 'Use paginated monster query to get more results',
+        options: [
+          { value: false, label: 'Off' },
+          { value: true, label: 'On' }
+        ]
+      }
+    }
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,18 @@
 import { Banner } from '@/components/banner';
 import MonsterGallery from '@/components/monsters/monster-gallery';
+import MonsterGalleryPaginated from '@/components/monsters/monster-gallery-paginated';
 import { Navbar } from '@/components/navbar';
+import { paginateMonstersFlag } from '@/flags';
 
-export default function Home() {
+export default async function Home() {
+  const paginatedMonsters = await paginateMonstersFlag();
+
   return (
     <div className='min-h-screen bg-background'>
       <Navbar />
       <main className='mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8'>
         <Banner />
-        <MonsterGallery />
+        {paginatedMonsters ? <MonsterGalleryPaginated /> : <MonsterGallery />}
       </main>
     </div>
   );

--- a/components/monsters/monster-gallery-paginated.tsx
+++ b/components/monsters/monster-gallery-paginated.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious
+} from '@/components/ui/carousel';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious
+} from '@/components/ui/pagination';
+import { usePaginatedQuery } from 'convex/react';
+import MonsterCard from '@/components/monsters/monster-card';
+import MonsterLeaderboard from '@/components/monsters/monster-leaderboard';
+import { api } from '@/convex/_generated/api';
+import { type CarouselApi } from '@/components/ui/carousel';
+import _ from 'lodash';
+
+export default function MonsterGalleryPaginated() {
+  const monsterCount = useRef(20);
+
+  const {
+    results: monsters,
+    status,
+    loadMore
+  } = usePaginatedQuery(
+    api.monsters.paginatedMonsters,
+    {},
+    { initialNumItems: 20 }
+  );
+
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [carouselApi, setCarouselApi] = useState<CarouselApi>();
+
+  const requestedMonsterId = searchParams.get('slide') || '';
+  const [currentSlide, setCurrentSlide] = useState(0);
+
+  const findMonsterIndex = useCallback(
+    (id: string) => {
+      return monsters?.findIndex((monster) => monster._id === id) ?? -1;
+    },
+    [monsters]
+  );
+
+  useEffect(() => {
+    if (
+      status === 'CanLoadMore' &&
+      monsterCount.current &&
+      monsterCount.current < 180
+    ) {
+      loadMore(20);
+      monsterCount.current = monsterCount.current + 20;
+    }
+
+    const initializeCarousel = async () => {
+      if (carouselApi && monsters) {
+        let index = findMonsterIndex(requestedMonsterId);
+        if (index === -1 && status === 'CanLoadMore') {
+          console.log('Loading more and checking again');
+          index = 1;
+          // index = await loadMoreAndCheckAgain();
+        }
+        if (index !== -1) {
+          carouselApi.scrollTo(index, true);
+          setCurrentSlide(index);
+        } else {
+          carouselApi.scrollTo(0, true);
+          setCurrentSlide(0);
+        }
+      }
+    };
+
+    initializeCarousel();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [carouselApi, monsters, requestedMonsterId, findMonsterIndex, status]);
+
+  useEffect(() => {
+    if (carouselApi) {
+      const onSelect = () => {
+        const selectedIndex = carouselApi.selectedScrollSnap();
+        setCurrentSlide(selectedIndex);
+        const selectedMonsterId = monsters?.[selectedIndex]?._id;
+        if (selectedMonsterId) {
+          router.push(`?slide=${selectedMonsterId}`, { scroll: false });
+        }
+      };
+
+      carouselApi.on('select', onSelect);
+      return () => {
+        carouselApi.off('select', onSelect);
+      };
+    }
+  }, [carouselApi, router, monsters]);
+
+  const handlePaginationClick = (index: number) => {
+    if (carouselApi) {
+      carouselApi.scrollTo(index);
+    }
+  };
+
+  const renderPaginationItems = () => {
+    if (!monsters) return null;
+
+    const items = [];
+    const totalPages = monsters.length;
+    const maxVisiblePages = 5;
+
+    if (totalPages <= maxVisiblePages) {
+      for (let i = 0; i < totalPages; i++) {
+        items.push(
+          <PaginationItem key={i}>
+            <PaginationLink
+              onClick={() => handlePaginationClick(i)}
+              isActive={currentSlide === i}
+            >
+              {i + 1}
+            </PaginationLink>
+          </PaginationItem>
+        );
+      }
+    } else {
+      const startPage = Math.max(
+        0,
+        Math.min(currentSlide - 2, totalPages - maxVisiblePages)
+      );
+      const endPage = Math.min(startPage + maxVisiblePages, totalPages);
+
+      if (startPage > 0) {
+        items.push(
+          <PaginationItem key='start'>
+            <PaginationLink onClick={() => handlePaginationClick(0)}>
+              1
+            </PaginationLink>
+          </PaginationItem>
+        );
+        if (startPage > 1) {
+          items.push(<PaginationEllipsis key='ellipsis-start' />);
+        }
+      }
+
+      for (let i = startPage; i < endPage; i++) {
+        items.push(
+          <PaginationItem key={i}>
+            <PaginationLink
+              onClick={() => handlePaginationClick(i)}
+              isActive={currentSlide === i}
+            >
+              {i + 1}
+            </PaginationLink>
+          </PaginationItem>
+        );
+      }
+
+      if (endPage < totalPages) {
+        if (endPage < totalPages - 1) {
+          items.push(<PaginationEllipsis key='ellipsis-end' />);
+        }
+        items.push(
+          <PaginationItem key='end'>
+            <PaginationLink
+              onClick={() => handlePaginationClick(totalPages - 1)}
+            >
+              {totalPages}
+            </PaginationLink>
+          </PaginationItem>
+        );
+      }
+    }
+
+    return items;
+  };
+
+  return (
+    <div className='container mx-auto flex flex-col space-y-8 p-8'>
+      <div className='flex flex-col md:flex-row md:space-x-8'>
+        <div className='mb-8 w-full md:mb-0 md:w-1/3'>
+          <MonsterLeaderboard />
+        </div>
+
+        <div className='w-full md:w-2/3'>
+          {monsters && monsters.length > 0 && (
+            <>
+              <Carousel
+                setApi={setCarouselApi}
+                className='mx-auto w-full max-w-2xl'
+              >
+                <CarouselContent>
+                  {_.orderBy(monsters, '_creationTime').map(
+                    (monster, index) => (
+                      <CarouselItem key={monster._id}>
+                        <MonsterCard monster={monster} />
+                      </CarouselItem>
+                    )
+                  )}
+                </CarouselContent>
+                <CarouselPrevious variant='default' />
+                <CarouselNext variant='default' />
+              </Carousel>
+              <div className='mt-4 flex justify-center'>
+                <Pagination>
+                  <PaginationContent>
+                    <PaginationItem>
+                      <PaginationPrevious
+                        onClick={() =>
+                          handlePaginationClick(Math.max(0, currentSlide - 1))
+                        }
+                      />
+                    </PaginationItem>
+                    {renderPaginationItems()}
+                    <PaginationItem>
+                      <PaginationNext
+                        onClick={() =>
+                          handlePaginationClick(
+                            Math.min(monsters.length - 1, currentSlide + 1)
+                          )
+                        }
+                      />
+                    </PaginationItem>
+                  </PaginationContent>
+                </Pagination>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/flags.ts
+++ b/flags.ts
@@ -1,0 +1,10 @@
+import { unstable_flag as flag } from '@vercel/flags/next';
+
+export const paginateMonstersFlag = flag({
+  key: 'paginate-monsters',
+  defaultValue: false,
+  description: 'Use paginated monster query to get more results',
+  decide: async () => false
+});
+
+export const precomputeFlags = [paginateMonstersFlag] as const;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react": "18.2.47",
         "@types/react-dom": "18.2.18",
         "@vercel/analytics": "^1.3.1",
+        "@vercel/flags": "^2.6.1",
         "ai": "^3.3.26",
         "autoprefixer": "10.4.16",
         "class-variance-authority": "^0.7.0",
@@ -2232,6 +2233,34 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/flags": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/flags/-/flags-2.6.1.tgz",
+      "integrity": "sha512-K+jSQAXZj2hBEtwyE/DwKX5atMlwoFoKe+2MIw8vNpYAMyVvEyyLFbbVjtmZWKRLW1k/bnbY71rsUI3ocEqsiQ==",
+      "dependencies": {
+        "jose": "5.2.1"
+      },
+      "peerDependencies": {
+        "@sveltejs/kit": "*",
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
           "optional": true
         }
       }
@@ -5152,6 +5181,15 @@
       "integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.1.tgz",
+      "integrity": "sha512-qiaQhtQRw6YrOaOj0v59h3R6hUY9NvxBmmnMfKemkqYmBB0tEc97NbLP7ix44VP5p9/0YHG8Vyhzuo5YBNwviA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-cookie": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/react": "18.2.47",
     "@types/react-dom": "18.2.18",
     "@vercel/analytics": "^1.3.1",
+    "@vercel/flags": "^2.6.1",
     "ai": "^3.3.26",
     "autoprefixer": "10.4.16",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
This pull request adds a feature flag for paginated monster queries. The `paginate-monsters` flag allows users to toggle between paginated and non-paginated monster queries. The flag is implemented in the `MonsterGalleryPaginated` component, which displays a carousel of monsters. When the flag is enabled, the component uses the `usePaginatedQuery` hook to fetch monsters in batches and display them in the carousel. The flag is set to `false` by default.